### PR TITLE
Rating bars now rendering green based on ratio of ratings

### DIFF
--- a/client/src/assets/styles.css
+++ b/client/src/assets/styles.css
@@ -104,3 +104,25 @@
   display: flex;
   flex-direction: column;
 }
+
+#ratingComponent {
+  display: flex;
+  border-style: solid;
+  flex-direction: column;
+}
+
+.rating {
+  display: flex;
+  align-items: center;
+}
+
+.ratingBar {
+  height: 10px;
+  width: 15%;
+  background-color: grey;
+}
+
+.ratingBarGreen {
+  height: 100%;
+  background-color: green;
+}

--- a/client/src/components/reviews/ratingbreakdown.jsx
+++ b/client/src/components/reviews/ratingbreakdown.jsx
@@ -4,25 +4,64 @@ const RatingBreakdown = ({ meta }) => {
   console.log(meta);
   let avgRating;
   let recommended;
+  let ratings = [];
+  let ratingRatio = [];
   if (meta.ratings) {
-    const ratings = Object.values(meta.ratings);
+    ratings = Object.values(meta.ratings);
     const totalRatings = ratings.reduce((acc, curr) => Number(acc) + Number(curr));
     avgRating = (ratings.reduce(
       (acc, curr, idx) => Number(acc) + (idx + 1) * Number(curr),
     )) / totalRatings;
     avgRating = Math.round(avgRating * 10) / 10;
-
     recommended = meta.recommended.true / (Number(meta.recommended.true)
-    + Number(meta.recommended.false));
+      + Number(meta.recommended.false));
     recommended = Math.round(recommended * 100);
+    ratingRatio = ratings.map((rating) => Math.round((rating / totalRatings) * 100));
   }
 
   return (
-    <div>
-        <h1>{avgRating}</h1>
-        <span>{recommended}% of reviews recommend this product</span>
+    <div id='ratingComponent'>
+      <h1>{avgRating}</h1>
+      <span>{recommended}% of reviews recommend this product</span>
+      <div id="ratingBreakdown">
+        Rating Breakdown
+        <div className="rating">
+          <span className="ratingLabel">5 Stars</span>
+          <div className="ratingBar">
+            <div className="ratingBarGreen" style={{ width: `${ratingRatio[4]}%` }}></div>
+          </div>
+            <div>{ratings[4]}</div>
+        </div>
+        <div className="rating">
+          <span className="ratingLabel">4 Stars</span>
+          <div className="ratingBar">
+            <div className="ratingBarGreen" style={{ width: `${ratingRatio[3]}%` }}></div>
+          </div>
+          <div>{ratings[3]}</div>
+        </div>
+        <div className="rating">
+          <span className="ratingLabel">3 Stars</span>
+          <div className="ratingBar">
+            <div className="ratingBarGreen" style={{ width: `${ratingRatio[2]}%` }}></div>
+          </div>
+          <div>{ratings[2]}</div>
+        </div>
+        <div className="rating">
+          <span className="ratingLabel">2 Stars</span>
+          <div className="ratingBar">
+            <div className="ratingBarGreen" style={{ width: `${ratingRatio[1]}%` }}></div>
+          </div>
+          <div>{ratings[1]}</div>
+        </div>
+        <div className="rating">
+          <span className="ratingLabel">1 Stars</span>
+          <div className="ratingBar">
+            <div className="ratingBarGreen" style={{ width: `${ratingRatio[0]}%` }}></div>
+          </div>
+          <div>{ratings[0]}</div>
+        </div>
+      </div>
     </div>
-
   );
 };
 

--- a/client/src/components/reviews/reviewlist.jsx
+++ b/client/src/components/reviews/reviewlist.jsx
@@ -11,12 +11,11 @@ const ReviewList = ({ productID }) => {
   const [meta, setMeta] = useState([]);
 
   useEffect(() => apiHelper.getReviews(count, sort, productID, setReviews), []);
-  useEffect(() => apiHelper.getReviews(count, sort, productID, setReviews), [count]);
-  useEffect(() => apiHelper.getReviews(count, sort, productID, setReviews), [sort]);
+  useEffect(() => apiHelper.getReviews(count, sort, productID, setReviews), [count, sort]);
   useEffect(() => apiHelper.getMeta(productID, setMeta), [reviews]);
 
   return (
-    <div>
+    <div id='reviewComponent'>
       <RatingBreakdown meta={meta}/>
       <Sort setSort={setSort}/>
       <div id='reviewAllTiles'>


### PR DESCRIPTION
- Requesting merge into reviewRatingBreakdown branch since these changes are made on top of that (there is a separate PR #22 for the initial merge of reviewRatingBreakdown). Once the changes here are accepted I will submit another PR from reviewRatingBreakdown into main.
- The big block of code in ratingsbreakdown.jsx represents all 5 of the ratings bars. Each bar shows a portion of green based on the ratio of ratings to total ratings. E.g. 100 total ratings with 20 five-star ratings will show 20% green and 80% grey. 
- Each "rating" div is essentially the same code, but uses the associated rating ratio/number of ratings. 
- Added styling in styles.css to make the above work. Currently I set each rating bar height to 10px to actually make it render something. Not sure if there is a better way of doing this to consider mobile devices. 
- One small change in reviewlist.jsx. Just consolidated two separate useEffects into one since the side effects for each were the same. 