### PR TITLE
1.4.2 related carousel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ package-lock.json
 .eslintrc.js
 .gitignore
 bundle.js
+coverage

--- a/client/src/assets/styles.css
+++ b/client/src/assets/styles.css
@@ -1,3 +1,4 @@
+/* RELATED CAROUSEL RELATED CAROUSEL*/
 
 .relatedPanel {
   display: flex;
@@ -8,15 +9,9 @@
 }
 
 
-/* RELATED CAROUSEL RELATED CAROUSEL*/
 .relatedCarousel    {
   display: flex;
-  /* width: 80%; */
-  /* padding:50px; */
-  /* flex-flow: wrap; */
-  /* margin: auto; */
   background-color: grey;
-  /* padding: 1%; */
   justify-content: flex-start;
 }
 
@@ -24,7 +19,6 @@
 /* RELATED CARD INDIVIDUAL CARD */
 
 .relatedCard  {
-  /* border: 3px solid darkgrey; */
   height: 300px;
   width: 10%;
   min-width: 150px;
@@ -51,7 +45,6 @@
   z-index: 1;
   font-size: 100%;
   color: yellow;
-  /* height: 1.5em; */
   width: 1.5em;
   background-color: rgb(255, 208, 0);
   border: 1% solid rgb(255, 208, 0);
@@ -132,7 +125,6 @@
 .relatedArrowOFF {
   border-radius: 50%;
   color: grey;
-  cursor: pointer;
 }
 #reviewAllTiles {
   display: flex;

--- a/client/src/assets/styles.css
+++ b/client/src/assets/styles.css
@@ -2,16 +2,22 @@
 .relatedPanel {
   display: flex;
   border: 10px solid grey;
+  background-color: grey;
+  width: auto;
+  justify-content: space-between;
 }
+
 
 /* RELATED CAROUSEL RELATED CAROUSEL*/
 .relatedCarousel    {
   display: flex;
-  padding:50px;
+  /* width: 80%; */
+  /* padding:50px; */
   /* flex-flow: wrap; */
+  /* margin: auto; */
   background-color: grey;
-  padding: 1%
-  /* justify-content: flex-start; */
+  /* padding: 1%; */
+  justify-content: flex-start;
 }
 
 
@@ -19,7 +25,7 @@
 
 .relatedCard  {
   /* border: 3px solid darkgrey; */
-  border-radius: 6px;
+  height: 300px;
   width: 10%;
   min-width: 150px;
   margin: 10px;
@@ -29,17 +35,14 @@
 
 .relatedProductImage {
   position: relative;
-  cursor: pointer
+  cursor: pointer;
+  overflow: hidden;
+  height: 175px;
+  display: flex;
+  justify-content: center;
+  /* height: 75%; */
 }
 
-.relatedProductImage img {
-  height: 100%;
-  width: 100%;
-  border-top-right-radius: 6px 6px;
-  border-top-left-radius: 6px 6px;
-  /* border-radius: 6px; */
-  position: relative
-}
 
 .relatedActionButton {
   position: absolute;
@@ -59,6 +62,7 @@
 }
 
 .relatedBottomTile {
+  height: 25%;
   display: flex;
   flex-flow: column;
   justify-content: space-between;
@@ -98,8 +102,8 @@
 
 .relatedFogOfWarR {
   background-color: grey;
-  width: 200px;
-  box-shadow: -35px 0px 25px grey;
+  width: 10%;
+  box-shadow:0px 0px 25px grey;
   display: flex;
   align-items: center;
   padding-right: 40px;
@@ -110,8 +114,8 @@
 
 .relatedFogOfWarL {
   background-color: grey;
-  width: 50px;
-  box-shadow: 25px 0px 25px grey;
+  width: 10%;
+  /* box-shadow: 25px 0px 25px grey; */
   display: flex;
   align-items: center;
   padding-right: 40px;

--- a/client/src/assets/styles.css
+++ b/client/src/assets/styles.css
@@ -125,6 +125,11 @@
   color: rgba(0, 0, 0, 0.598);
   cursor: pointer;
 }
+.relatedArrowOFF {
+  border-radius: 50%;
+  color: grey;
+  cursor: pointer;
+}
 #reviewAllTiles {
   display: flex;
   flex-direction: column;

--- a/client/src/components/Related/Carousel.jsx
+++ b/client/src/components/Related/Carousel.jsx
@@ -15,41 +15,42 @@ const RelatedCarousel = ({numberOfTiles, productID, setProductID, position, setP
 
   const clickRightArrow = () => {
     console.log('ARROW CLICKED');
-    if (position + 2 < related.length) {setPosition(position + 1)};
+    if (position + 2 < related.length) {setPosition(position + 1); }
   };
   const clickLeftArrow = () => {
     console.log('ARROW CLICKED');
-    if (position > 0) { setPosition(position - 1)}
+    if (position > 0) { setPosition(position - 1); }
   };
 
   uniqueRelated = [...new Set(related)];
   slicedRelated = uniqueRelated
-  slicedRelated = slicedRelated.slice(position, numberOfTiles+position);
-  relatedComponents = slicedRelated.map( id => {
+  slicedRelated = slicedRelated.slice(position, numberOfTiles + position);
+  relatedComponents = slicedRelated.map(id => {
     return (
     <RelatedProductCard key={id} productID={id} setProductID={setProductID} setPosition={setPosition} />
     )});
 
 
 
+    const leftArrow = position > 0
+      ? <div className ="relatedArrow" onClick={clickLeftArrow}> {'<'} </div>
+      : <div className ="relatedArrowOFF" > {'<'} </div>;
 
-  const rightArrow = uniqueRelated.length > relatedComponents.length
-   && position + 1 < uniqueRelated.length
+  const rightArrow = position + numberOfTiles < uniqueRelated.length
     ? <div className ="relatedArrow" onClick={clickRightArrow}> {'>'} </div>
-    : <div className ="relatedArrowOFF" onClick={clickRightArrow}> {'>'} </div>;
-  const leftArrow = position > 0
-    ? <div className ="relatedArrow" onClick={clickLeftArrow}> {'<'} </div>
-    : <div className ="relatedArrowOFF" onClick={clickLeftArrow}> {'<'} </div>;
+    : <div className ="relatedArrowOFF"> {'>'} </div>;
 
 
   return (
-      <div className="relatedPanel" position={position}>
+      <div className="relatedPanel">
           <div className="relatedFogOfWarL">
-        {leftArrow}
+             {leftArrow}
           </div>
-        <div className="relatedCarousel">
-          {relatedComponents}
-        </div>
+          {/* <div> */}
+            <div className="relatedCarousel">
+              {relatedComponents}
+            {/* </div> */}
+          </div>
           <div className="relatedFogOfWarR">
             {rightArrow}
           </div>

--- a/client/src/components/Related/Carousel.jsx
+++ b/client/src/components/Related/Carousel.jsx
@@ -15,11 +15,11 @@ const RelatedCarousel = ({numberOfTiles, productID, setProductID, position, setP
 
   const clickRightArrow = () => {
     console.log('ARROW CLICKED');
-    setPosition(position + 1);
+    if (position + 2 < related.length) {setPosition(position + 1)};
   };
   const clickLeftArrow = () => {
     console.log('ARROW CLICKED');
-    setPosition(position - 1);
+    if (position > 0) { setPosition(position - 1)}
   };
 
   uniqueRelated = [...new Set(related)];
@@ -33,11 +33,13 @@ const RelatedCarousel = ({numberOfTiles, productID, setProductID, position, setP
 
 
 
-  const rightArrow = uniqueRelated.length > relatedComponents.length ?
-    <div className ="relatedArrow" onClick={clickRightArrow}> {'>'} </div> :
-    <div className ="relatedArrow" onClick={clickRightArrow}> {''} </div>;
- const leftArrow = position >= 1 ? <div className ="relatedArrow" onClick={clickLeftArrow}> {'<'} </div> :
- <div className ="relatedArrow" onClick={clickLeftArrow}> {''} </div>;
+  const rightArrow = uniqueRelated.length > relatedComponents.length
+   && position + 1 < uniqueRelated.length
+    ? <div className ="relatedArrow" onClick={clickRightArrow}> {'>'} </div>
+    : <div className ="relatedArrowOFF" onClick={clickRightArrow}> {'>'} </div>;
+  const leftArrow = position > 0
+    ? <div className ="relatedArrow" onClick={clickLeftArrow}> {'<'} </div>
+    : <div className ="relatedArrowOFF" onClick={clickLeftArrow}> {'<'} </div>;
 
 
   return (

--- a/client/src/components/Related/Carousel.jsx
+++ b/client/src/components/Related/Carousel.jsx
@@ -1,36 +1,27 @@
 import React from 'react';
 import RelatedProductCard from './RelatedProductCard.jsx';
-import apiHelper from './apihelpers.jsx';
 
-const { useEffect, useState, useRef } = React;
 let uniqueRelated = [];
 let slicedRelated = [];
 let relatedComponents = [];
 
 const RelatedCarousel = ({numberOfTiles, productID, setProductID, position, setPosition, related, setRelated }) => {
-  console.log({numberOfTiles});
-  console.log({position})
-  console.log({related})
-
-
   const clickRightArrow = () => {
-    console.log('ARROW CLICKED');
+    console.log('Right ARROW CLICKED');
     if (position + 2 < related.length) {setPosition(position + 1); }
   };
   const clickLeftArrow = () => {
-    console.log('ARROW CLICKED');
+    console.log('Left ARROW CLICKED');
     if (position > 0) { setPosition(position - 1); }
   };
 
   uniqueRelated = [...new Set(related)];
-  slicedRelated = uniqueRelated
+  slicedRelated = uniqueRelated;
   slicedRelated = slicedRelated.slice(position, numberOfTiles + position);
   relatedComponents = slicedRelated.map(id => {
     return (
     <RelatedProductCard key={id} productID={id} setProductID={setProductID} setPosition={setPosition} />
     )});
-
-
 
     const leftArrow = position > 0
       ? <div className ="relatedArrow" onClick={clickLeftArrow}> {'<'} </div>

--- a/client/src/components/Related/RelatedProductCard.jsx
+++ b/client/src/components/Related/RelatedProductCard.jsx
@@ -3,11 +3,14 @@ import apiHelper from './apihelpers.jsx';
 
 const { useState, useEffect } = React;
 
-const RelatedProductsCard = ({ productID, setProductID, setPosition }) => {
+const RelatedProductsCard = ({ productID, setProductID, position, setPosition }) => {
   const related = true;
   const [name, setName] = useState('');
   const [price, setPrice] = useState('');
   const [category, setCategory] = useState('');
+
+  const [productImage, setProductImage] = useState('https://cdn.shopify.com/s/files/1/0419/1525/products/1024x1024-Men-Captain-Tobacco-043021-2.jpg?v=1620400973')
+
 
   useEffect(() => {
     apiHelper.getProduct(productID)
@@ -17,6 +20,10 @@ const RelatedProductsCard = ({ productID, setProductID, setPosition }) => {
         setCategory(res.data.category);
       })
       .catch((err) => console.error(err));
+    apiHelper.getStyles(productID)
+      .then((res) => {
+        setProductImage(res.data.results[0].photos[0].thumbnail_url)
+      })
   }, []);
 
   const cardClick = () => {
@@ -31,12 +38,13 @@ const RelatedProductsCard = ({ productID, setProductID, setPosition }) => {
   };
 
   const actionText = related ? '★' : 'X';
+  console.log(productImage)
 
   return (
     <div className="relatedCard" >
       <div className="relatedProductImage">
         <div className="relatedActionButton" onClick={actionClick}> {actionText} </div>
-        <img onClick={cardClick} src="https://cdn.shopify.com/s/files/1/0419/1525/products/1024x1024-Men-Captain-Tobacco-043021-2.jpg?v=1620400973">
+        <img onClick={cardClick} src={productImage}>
         </img>
       </div>
       <div className="relatedBottomTile" onClick={cardClick}>
@@ -53,3 +61,4 @@ export default RelatedProductsCard;
 
 //GET /products/:product_id/related
 //returns [40946,40831,41246] array of numbers to utilize for related list
+{/* "https://cdn.shopify.com/s/files/1/0419/1525/products/1024x1024-Men-Captain-Tobacco-043021-2.jpg?v=1620400973" */}

--- a/client/src/components/Related/RelatedProductCard.jsx
+++ b/client/src/components/Related/RelatedProductCard.jsx
@@ -22,23 +22,20 @@ const RelatedProductsCard = ({ productID, setProductID, position, setPosition })
       .catch((err) => console.error(err));
     apiHelper.getStyles(productID)
       .then((res) => {
-        setProductImage(res.data.results[0].photos[0].thumbnail_url)
-      })
+        setProductImage(res.data.results[0].photos[0].thumbnail_url);
+      });
   }, []);
 
   const cardClick = () => {
     setProductID(productID);
     setPosition(0);
-    console.log(productID)
   };
 
   const actionClick = () => {
     console.log("ACTION CLICKED")
-    console.log(window.innerWidth, window.innerHeight);
   };
 
   const actionText = related ? '★' : 'X';
-  console.log(productImage)
 
   return (
     <div className="relatedCard" >

--- a/client/src/components/Related/RelatedWidget.jsx
+++ b/client/src/components/Related/RelatedWidget.jsx
@@ -8,7 +8,7 @@ const {useState, useEffect} = React;
 const RelatedWidget = ({productID, setProductID}) => {
   const [position, setPosition] = useState(0);
   const [related, setRelated] = useState([Number(productID)]);
-  const [numberOfTiles, setNumberOfTiles] = useState(4);
+  const [numberOfTiles, setNumberOfTiles] = useState(Math.floor(window.innerWidth / 217));
 
 
   useEffect(() => {
@@ -23,6 +23,8 @@ const RelatedWidget = ({productID, setProductID}) => {
     };
     window.addEventListener('resize', handleResize);
   }, [productID, window.innerWidth]);
+
+  console.log(numberOfTiles)
 
   return (
     <Carousel related={related} numberOfTiles={numberOfTiles}  setRelated={setRelated} productID={productID} setProductID={setProductID} position={position} setPosition={setPosition}/>

--- a/client/src/components/Related/RelatedWidget.jsx
+++ b/client/src/components/Related/RelatedWidget.jsx
@@ -10,7 +10,6 @@ const RelatedWidget = ({ productID, setProductID }) => {
   const [related, setRelated] = useState([Number(productID)]);
   const [numberOfTiles, setNumberOfTiles] = useState(Math.floor(window.innerWidth / 217) - 1);
 
-
   useEffect(() => {
     apiHelper.getRelated(productID)
       .then((res) => {
@@ -23,8 +22,6 @@ const RelatedWidget = ({ productID, setProductID }) => {
     };
     window.addEventListener('resize', handleResize);
   }, [productID, window.innerWidth]);
-
-  console.log(numberOfTiles)
 
   return (
     <Carousel related={related} numberOfTiles={numberOfTiles}  setRelated={setRelated} productID={productID} setProductID={setProductID} position={position} setPosition={setPosition}/>

--- a/client/src/components/Related/RelatedWidget.jsx
+++ b/client/src/components/Related/RelatedWidget.jsx
@@ -5,10 +5,10 @@ import Carousel from './Carousel.jsx';
 
 const {useState, useEffect} = React;
 
-const RelatedWidget = ({productID, setProductID}) => {
+const RelatedWidget = ({ productID, setProductID }) => {
   const [position, setPosition] = useState(0);
   const [related, setRelated] = useState([Number(productID)]);
-  const [numberOfTiles, setNumberOfTiles] = useState(Math.floor(window.innerWidth / 217));
+  const [numberOfTiles, setNumberOfTiles] = useState(Math.floor(window.innerWidth / 217) - 1);
 
 
   useEffect(() => {
@@ -19,7 +19,7 @@ const RelatedWidget = ({productID, setProductID}) => {
       .catch((err) => console.error(err));
     const handleResize = (numberOfTiles) => {
       console.log('RESIZE', window.innerWidth, window.innerHeight);
-      setNumberOfTiles(Math.floor(window.innerWidth / 217));
+      setNumberOfTiles(Math.floor(window.innerWidth / 217) - 1);
     };
     window.addEventListener('resize', handleResize);
   }, [productID, window.innerWidth]);

--- a/client/src/components/Related/apihelpers.jsx
+++ b/client/src/components/Related/apihelpers.jsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 const apiHelper = {
   getProduct: (id) => axios.get('/sean', { params: { endpoint: id } }),
   getRelated: (id) => axios.get('/sean/related', { params: { endpoint: id } }),
+  getStyles: (id) => axios.get('/sean/styles', { params: { endpoint: id } }),
 };
 
 export default apiHelper;

--- a/client/src/components/Related/related.test.js
+++ b/client/src/components/Related/related.test.js
@@ -1,0 +1,5 @@
+import Carousel from './Carousel.jsx';
+
+test('expect Carousel RelatedComponent to NOT be empty', () => {
+  expect(typeof Carousel).toBe('function');
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "sd": "npx nodemon --watch server server/index.js",
     "cd": "npx webpack --watch",
     "build": "npx webpack",
-    "start": "node server/index.js"
+    "start": "node server/index.js",
+    "test": "jest --coverage"
   },
   "dependencies": {
     "@testing-library/react": "^14.0.0",

--- a/server/controllers/controllerssean.js
+++ b/server/controllers/controllerssean.js
@@ -28,5 +28,17 @@ const getRelated = (req, res) => {
     .catch((err) => res.status(500).send(err));
 };
 
+const getStyles = (req, res) => {
+  let options = {
+    url: `https://app-hrsei-api.herokuapp.com/api/fec2/hr-rfp/products/${req.query.endpoint}/styles`, //${req.query.endpoint}
+    headers: {
+      'Authorization': `${process.env.API_TOKEN}`
+    },
+  };//
 
-module.exports = { get, getRelated };
+  axios.get(options.url, { headers: options.headers })
+    .then(({ data }) => res.status(200).send(data))
+    .catch((err) => res.status(500).send(err));
+};
+
+module.exports = { get, getRelated, getStyles };

--- a/server/routes/routessean.js
+++ b/server/routes/routessean.js
@@ -3,5 +3,6 @@ const controllers = require('../controllers/controllerssean');
 
 Router.get('/', controllers.get);
 Router.get('/related', controllers.getRelated);
+Router.get('/styles', controllers.getStyles);
 
 module.exports = Router;


### PR DESCRIPTION
I am rendering images, and general details, sales price is not yet implemented.
Essentially, the tile component is complete in functionality.

The primary goal for tomorrow is to complete the modal popup upon clicking the action button.  

In this pull request i created custom component called "RelatedWidget", it is functions as a state holder that was necessary for correct re-rendering when clicking on tiles.  
RelatedWidget is where the window.innerWidth information is stored.

The Width of the screen dictates how many tiles can fit in the screen and is passed down to RelatedCarousel.
RelatedCarousel in turn .maps through the related products and utilizes numberOfTiles to reduce the total to fit the screen. 
If there is overflow, arrows appear so the client can tab through the component.