### PR TITLE
Stars added to review component

### DIFF
--- a/client/src/assets/styles.css
+++ b/client/src/assets/styles.css
@@ -278,6 +278,29 @@
   justify-content: space-between;
 }
 
+.ratingBreakdownAverage {
+  font-size: 250%;
+  font-weight: bold;
+  margin-top: 1%;
+}
+
+.reviewStars {
+  --percent: calc(var(--rating) / 5 * 100%);
+
+  display: inline-block;
+  font-size: 30px;
+  font-family: Times;
+  line-height: 1;
+
+  &::before {
+    content: '★★★★★';
+    letter-spacing: 3px;
+    background: linear-gradient(90deg, var(--star-background) var(--percent), var(--star-color) var(--percent));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+}
+
 #ratingRecommend {
   font-size: 80%;
   padding-bottom: 3%;

--- a/client/src/components/reviews/ratingbreakdown.jsx
+++ b/client/src/components/reviews/ratingbreakdown.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import Star from '../starRating.jsx';
+import Stars from './reviewStarRating.jsx';
 
-const RatingBreakdown = ({ meta, productID }) => {
+const RatingBreakdown = ({ meta }) => {
   console.log(meta);
   let avgRating;
   let recommended;
@@ -23,7 +23,7 @@ const RatingBreakdown = ({ meta, productID }) => {
   return (
     <div id='ratingComponent'>
       <h6 id='ratingBreakdownHeader'>RATING BREAKDOWN</h6>
-      <h1>{avgRating}</h1>
+      <h1 className='ratingBreakdownAverage'>{avgRating}<Stars averageRating={avgRating}/></h1>
       <span id='ratingRecommend'>{recommended}% of reviews recommend this product</span>
       <div id="ratingBreakdown">
         <div className="rating">

--- a/client/src/components/reviews/reviewStarRating.jsx
+++ b/client/src/components/reviews/reviewStarRating.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Star = ({ averageRating }) => {
+  const style = { '--rating': averageRating };
+  return (
+    <div className="reviewStars" style={style} aria-label={`Rating of this product is ${averageRating} out of 5.`}></div>);
+};
+
+export default Star;

--- a/client/src/components/reviews/reviewlist.jsx
+++ b/client/src/components/reviews/reviewlist.jsx
@@ -20,14 +20,14 @@ const ReviewList = ({ productID }) => {
     <div>
       <div id='reviewComponent'>
         <div id='breakdowns'>
-          <RatingBreakdown meta={meta} productID={productID}/>
+          <RatingBreakdown meta={meta}/>
           <ProductBreakdown meta={meta}/>
         </div>
         <div id='reviewAllTiles'>
         <Sort setSort={setSort} reviews={reviews}/>
         <NewReview productID={productID} meta={meta}/>
         {reviews.results && reviews.results.slice(0, count).map((review) => <ReviewTile
-        key={review.review_id} review={review} />)}
+        key={review.review_id} review={review}/>)}
           <div className='buttons'>
             <button className='reviewButton' type="button" onClick={() => { setCount(count + 2); }}>More reviews</button>
             <button className='newReviewButton' type="button" onClick={() => { document.getElementById('newReview').showModal(); }} >Write a review</button>

--- a/client/src/components/reviews/reviewtile.jsx
+++ b/client/src/components/reviews/reviewtile.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import Stars from './reviewStarRating.jsx';
 
 const ReviewTile = ({ review }) => (
   <div className='reviewTile'>
     <header className='reviewHeader'>
-      <div>{review.rating}</div>
+      <div className='reviewTileStars'><Stars averageRating={review.rating}/></div>
       <div>{review.reviewer_name} {review.date}</div>
     </header>
     <section className='reviewContent'>

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -12,7 +12,7 @@ const App = () => {
 
   return (
     <div>
-      <Overview productID={productID} />
+      {/* <Overview productID={productID} /> */}
       {/* <RelatedWidget productID={productID} setProductID={setProductID}/> */}
       {/* <Overview productID={productID} /> */}
       {/* <ReviewList productID={productID}/> */}


### PR DESCRIPTION
- Created a new file reviewStarRating.jsx in /reviews
- Modified version of Matthew's starRating.jsx, to accept rating as an input prop as opposed to productID
- Since meta data already exists in rating breakdown and average rating is subsequently calculated, it was redundant to make another get request within starRating and recalculate the average.
- Since each review tile has it's own rating, unrelated to the productID's average rating, I changed my version of star rating to accept a specific rating number.