### PR TITLE
Refactored new review form characteristics section

### DIFF
--- a/client/src/assets/styles.css
+++ b/client/src/assets/styles.css
@@ -621,12 +621,11 @@ BarLoader {
 
 .newCharacteristicBlock {
   display: flex;
-  align-self: center;
   flex-direction: column;
   border: solid;
   border-width: 1px;
   margin-bottom: 1%;
-  width: 90%;
+  width: 50%;
 }
 
 .newCharacteristicHeader {
@@ -634,15 +633,20 @@ BarLoader {
   font-weight: bold;
 }
 
+.newSelectedCharacteristic {
+  align-self: center;
+  font-size: 80%;
+}
+
 .newCharacteristic {
   display: flex;
   justify-content: space-around;
 }
 
-.newDescription {
-  display:flex;
-  flex-direction: column;
-  font-size: 80%;
+.newRange {
+  display: flex;
+  font-size: 70%;
+  justify-content: space-between;
 }
 
 .newPhoto {

--- a/client/src/components/reviews/newreview.jsx
+++ b/client/src/components/reviews/newreview.jsx
@@ -10,6 +10,7 @@ const NewReview = ({ productID, meta }) => {
   const [photos, setPhotos] = useState([]);
   const [product, setProduct] = useState([]);
   const [numStars, setNumStars] = useState(0);
+  const [selectedChar, setSelectedChar] = useState({});
 
   useEffect(() => {
     apiHelperSean.getProduct(productID)
@@ -131,13 +132,19 @@ const NewReview = ({ productID, meta }) => {
           {meta.characteristics && Object.keys(meta.characteristics).map((characteristic) => (
             <div key={characteristic} className='newCharacteristicBlock'>
               <div className='newCharacteristicHeader'>{characteristic}</div>
+              <div className='newSelectedCharacteristic'>
+                {descriptions[characteristic][selectedChar[characteristic] - 1] || 'none selected'}
+              </div>
               <div className='newCharacteristic'>
                 {descriptions[characteristic].map((description, idx) => (
                   <div className='newDescription' key={`${characteristic}${idx}`}>
-                    <label htmlFor={`${characteristic}${idx}`}>{description}</label>
-                    <input type='radio' name={meta.characteristics[characteristic].id} id={`${characteristic}${idx}`} value={idx + 1} required/>
+                    <input type='radio' name={meta.characteristics[characteristic].id} id={`${characteristic}${idx}`} value={idx + 1} required onChange={(e) => setSelectedChar({ ...selectedChar, [characteristic]: e.target.value })}/>
                   </div>
                 ))}
+              </div>
+              <div className='newRange'>
+                <div>{descriptions[characteristic][0]}</div>
+                <div>{descriptions[characteristic][4]}</div>
               </div>
             </div>
           ))}


### PR DESCRIPTION
- Reread the business requirements and realized I misinterpreted what they were asking for
- Previously each characteristic's rating description was shown, but the business requirement states that only descriptions should be shown for ratings = 1 or 5. 
- Upon making a selection, the current selection's description is shown above the radio buttons
- If no selection is made, 'none selected' appears above the radio buttons. 