### PR TITLE
Set max photo size on full resolution

### DIFF
--- a/client/src/assets/styles.css
+++ b/client/src/assets/styles.css
@@ -534,6 +534,7 @@ BarLoader {
   padding: 1%;
   background-color: white;
   box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
+  min-width: 230px;
 }
 
 #ratingComponent {
@@ -620,6 +621,7 @@ BarLoader {
   width: 20%;
   white-space: nowrap;
 }
+
 .ratingBarGreen {
   height: 100%;
   background-color: green;

--- a/client/src/components/reviews/reviewlist.jsx
+++ b/client/src/components/reviews/reviewlist.jsx
@@ -24,6 +24,7 @@ const ReviewList = ({ productID, mainData }) => {
     setClicked(false);
     setScrolledCount(6);
     setSort('relevant');
+    document.getElementById('searchBar').value = '';
     document.getElementById('showMoreOnce').style.display = 'inline';
   }, [productID]);
 

--- a/client/src/components/reviews/reviewtile.jsx
+++ b/client/src/components/reviews/reviewtile.jsx
@@ -46,7 +46,7 @@ const ReviewTile = ({ review, term }) => {
             <div className='reviewPhoto' key={photo.url}>
               <img onClick={() => document.getElementById(`${photo.url}`).showModal()} className='reviewThumbnail' src={photo.url}/>
               <dialog id={photo.url} onClick={() => document.getElementById(`${photo.url}`).close()}>
-                <img src={photo.url}/>
+                <img src={photo.url} style={{ maxHeight: '1000px', maxWidth: '1000px' }}/>
               </dialog>
           </div>
           ))}


### PR DESCRIPTION
- Some photos at full resolution were extremely large
- Set a max photo rendering size to 1000 x 1000 pixels
- Also clearing search bar input field when productID changes
- Also set a minimum width for the rating breakdowns section on the left side so text would not overflow outside of the box