### PR TITLE
removed mathewEndpoint error... because StarRating needs prodID input

### DIFF
--- a/client/src/components/Related/Carousel.jsx
+++ b/client/src/components/Related/Carousel.jsx
@@ -41,7 +41,7 @@ const RelatedCarousel = ({
   if (relatedList === undefined) {
     // eslint-disable-next-line no-plusplus
     for (let i = 0; i < numberOfTiles; i++) {
-      relatedComponents.push(<EmptyCard key={i} productID={productID}/>);
+      relatedComponents.push(<EmptyCard key={i}/>);
     }
   }
 

--- a/client/src/components/Related/EmptyCard.jsx
+++ b/client/src/components/Related/EmptyCard.jsx
@@ -15,7 +15,7 @@ const EmptyCard = () => {
         <div className="relatedCategory"></div>
         <strong className="relatedProductName"></strong>
         <div className="relatedPrice"> </div>
-        <StarRating/>
+        <div>☆☆☆☆☆</div>
       </div>
     </div>
   );


### PR DESCRIPTION
I utilized Mathew's StarRating component in my EmptyCard component and because i did not pass in a productID we had endpoint issues.
